### PR TITLE
Lt 4585 rf qs get multiplied when timeout

### DIFF
--- a/src/MarginTrading.Backend.Services/Workflow/SpecialLiquidation/SpecialLiquidationCommandsHandler.cs
+++ b/src/MarginTrading.Backend.Services/Workflow/SpecialLiquidation/SpecialLiquidationCommandsHandler.cs
@@ -318,9 +318,17 @@ namespace MarginTrading.Backend.Services.Workflow.SpecialLiquidation
 
             if (executionInfo?.Data != null)
             {
-                if (executionInfo.Data.State > SpecialLiquidationOperationState.PriceRequested
-                    || executionInfo.Data.RequestNumber > command.RequestNumber)
+                if (executionInfo.Data.State > SpecialLiquidationOperationState.PriceRequested)
                 {
+                    await _log.WriteInfoAsync(nameof(SpecialLiquidationCommandsHandler), nameof(GetPriceForSpecialLiquidationTimeoutInternalCommand),
+                        $"Price for special liquidation {command.OperationId} has already been requested. State: {executionInfo.Data.State.ToString()}. Skipping timeout event.");
+                    return CommandHandlingResult.Ok();
+                }
+                
+                if (executionInfo.Data.RequestNumber > command.RequestNumber)
+                {
+                    await _log.WriteInfoAsync(nameof(SpecialLiquidationCommandsHandler), nameof(GetPriceForSpecialLiquidationTimeoutInternalCommand),
+                        $"Price for special liquidation {command.OperationId} has already been requested. Request number: {executionInfo.Data.RequestNumber} and command reequest number: {command.RequestNumber}. Skipping timeout event.");
                     return CommandHandlingResult.Ok();
                 }
 

--- a/src/MarginTrading.Backend.Services/Workflow/SpecialLiquidation/SpecialLiquidationSaga.cs
+++ b/src/MarginTrading.Backend.Services/Workflow/SpecialLiquidation/SpecialLiquidationSaga.cs
@@ -511,6 +511,12 @@ namespace MarginTrading.Backend.Services.Workflow.SpecialLiquidation
             IOperationExecutionInfo<SpecialLiquidationOperationData> executionInfo,
             TimeSpan retryTimeout)
         {
+            // fix the intention to make another price request to not let the parallel 
+            // ongoing GetPriceForSpecialLiquidationTimeoutInternalCommand execution
+            // break (fail) the flow
+            executionInfo.Data.NextRequestNumber();
+            await _operationExecutionInfoRepository.Save(executionInfo);
+            
             var shouldRetryAfter = eventCreationTime.Add(retryTimeout);
 
             var timeLeftBeforeRetry = shouldRetryAfter - _dateService.Now();
@@ -520,11 +526,7 @@ namespace MarginTrading.Backend.Services.Workflow.SpecialLiquidation
                 await Task.Delay(timeLeftBeforeRetry);
             }
 
-            executionInfo.Data.NextRequestNumber();
-
             RequestPrice(sender, executionInfo);
-
-            await _operationExecutionInfoRepository.Save(executionInfo);
         }
 
         private async Task<bool> FailIfInstrumentDiscontinued(IOperationExecutionInfo<SpecialLiquidationOperationData> executionInfo, ICommandSender sender)


### PR DESCRIPTION
This is because there are might be parallel ongoing processes which handle GetPriceForSpecialLiquidationTimeoutInternalCommand. To not let GetPriceForSpecialLiquidationTimeoutInternalCommand fail the flow with subsequent unexpected outcome we seize the initiative here so that the flow will continue with retry after some delay.