### PR TITLE
Lt 4778 trading core force cache update on accounts

### DIFF
--- a/src/MarginTrading.Backend.Services/Infrastructure/SnapshotService.cs
+++ b/src/MarginTrading.Backend.Services/Infrastructure/SnapshotService.cs
@@ -17,6 +17,7 @@ using MarginTrading.Backend.Core.Snapshots;
 using MarginTrading.Backend.Services.AssetPairs;
 using MarginTrading.Backend.Services.Mappers;
 using MarginTrading.Common.Services;
+using MoreLinq;
 
 namespace MarginTrading.Backend.Services.Infrastructure
 {
@@ -144,6 +145,10 @@ namespace MarginTrading.Backend.Services.Infrastructure
                             @$"Account {accountStat.Id}, TotalBlockedMargin {margin}, {accountStat.LogInfo}");
                     }
                 }
+
+                // Forcing all account caches to be updated after trading is closed - after all events have been processed
+                // To ensure all cache data is updated with most up-to date data for all accounts.
+                accountStats.ForEach(a => a.CacheNeedsToBeUpdated());
 
                 var accountsInLiquidation = await _accountsCacheService.GetAllInLiquidation().ToListAsync();
                 var accountsJson = accountStats

--- a/src/MarginTrading.Backend.Services/Services/AccountUpdateService.cs
+++ b/src/MarginTrading.Backend.Services/Services/AccountUpdateService.cs
@@ -219,7 +219,9 @@ namespace MarginTrading.Backend.Services.Services
             account.AccountFpl.CalculatedHash = account.AccountFpl.ActualHash;
 
             var accuracy = AssetsConstants.DefaultAssetAccuracy;
-            var positionsMaintenanceMargin = positions.Sum(item => item.GetMarginMaintenance());
+            var positionsMaintenanceMarginValues = positions.Select(item => item.GetMarginMaintenance());
+            var positionsMaintenanceMargin = positionsMaintenanceMarginValues.Sum();
+
             var positionsInitMargin = positions.Sum(item => item.GetMarginInit());
             var pendingOrdersMargin = 0;
 
@@ -232,7 +234,9 @@ namespace MarginTrading.Backend.Services.Services
             if (_marginTradingSettings.LogBlockedMarginCalculation)
             {
                 var positionsMaintenanceMarginLog = string.Join(" + ", positions.Select(item => $"posId: {item.Id}, {item.GetMarginMaintenance().ToString(CultureInfo.InvariantCulture)}"));
-                account.LogInfo = $"PositionsMaintenanceMargin: {positionsMaintenanceMargin} = {positionsMaintenanceMarginLog} - LastUpdate: {DateTime.UtcNow}";
+
+                account.LogInfo = @$"PositionsMaintenanceMargin: {positionsMaintenanceMargin} = {positionsMaintenanceMarginLog}. 
+                    Summed values: {positionsMaintenanceMargin.ToJson()} - LastUpdate: {DateTime.UtcNow}";
             }
             
             account.AccountFpl.MarginInit = Math.Round(positionsInitMargin + pendingOrdersMargin, accuracy);

--- a/src/MarginTrading.Backend.Services/Services/AccountUpdateService.cs
+++ b/src/MarginTrading.Backend.Services/Services/AccountUpdateService.cs
@@ -11,7 +11,6 @@ using Common.Log;
 using JetBrains.Annotations;
 using Lykke.Snow.Common.Costs;
 using Lykke.Snow.Common.Percents;
-using Lykke.Snow.Common.Quotes;
 using MarginTrading.AssetService.Contracts.ClientProfileSettings;
 using MarginTrading.Backend.Core;
 using MarginTrading.Backend.Core.Exceptions;
@@ -233,7 +232,7 @@ namespace MarginTrading.Backend.Services.Services
             if (_marginTradingSettings.LogBlockedMarginCalculation)
             {
                 var positionsMaintenanceMarginLog = string.Join(" + ", positions.Select(item => $"posId: {item.Id}, {item.GetMarginMaintenance().ToString(CultureInfo.InvariantCulture)}"));
-                account.LogInfo = $"PositionsMaintenanceMargin: {positionsMaintenanceMargin} = {positionsMaintenanceMarginLog}";
+                account.LogInfo = $"PositionsMaintenanceMargin: {positionsMaintenanceMargin} = {positionsMaintenanceMarginLog} - LastUpdate: {DateTime.UtcNow}";
             }
             
             account.AccountFpl.MarginInit = Math.Round(positionsInitMargin + pendingOrdersMargin, accuracy);
@@ -253,7 +252,7 @@ namespace MarginTrading.Backend.Services.Services
             if(_marginTradingSettings.LogBlockedMarginCalculation && SnapshotService.IsMakingSnapshotInProgress)
             {
                 _log.WriteInfo(nameof(AccountUpdateService), positions?.Select(p => new { p.Id, p.AssetPairId, p.ClosePrice, p.CloseFxPrice }).ToJson(), 
-                    $"Position array from position provider");
+                    $"Account {accountId} - Position array from position provider");
             }
 
             return positions;


### PR DESCRIPTION
It turns out that two positions with the same instruments can have different values if a quote is consumed during an account's cache update.

This PR introduces changes to ensure all account data is evaluated during snapshot creation, rather than putting cached account data into trading snapshot.

Also small changes to enhance existing logs