### PR TITLE
fix(LT-4925): upgrade lykke.snow.common to 2.7.3

### DIFF
--- a/src/MarginTrading.Backend.Services/MarginTrading.Backend.Services.csproj
+++ b/src/MarginTrading.Backend.Services/MarginTrading.Backend.Services.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Lykke.Service.ClientAccount.Client" Version="3.2.0" />
     <PackageReference Include="Lykke.Service.EmailSender" Version="1.1.0" />
     <PackageReference Include="Lykke.Service.Session" Version="16.0.0" />
-    <PackageReference Include="Lykke.Snow.Common" Version="2.6.0" />
+    <PackageReference Include="Lykke.Snow.Common" Version="2.7.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/src/MarginTrading.Backend.TestClient/MarginTrading.Backend.TestClient.csproj
+++ b/src/MarginTrading.Backend.TestClient/MarginTrading.Backend.TestClient.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.4.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Lykke.Snow.Common" Version="2.6.0" />
+    <PackageReference Include="Lykke.Snow.Common" Version="2.7.3" />
     <PackageReference Include="LykkeBiz.HttpClientGenerator" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/src/MarginTrading.Backend/MarginTrading.Backend.csproj
+++ b/src/MarginTrading.Backend/MarginTrading.Backend.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="LykkeBiz.Logs.Serilog" Version="3.3.1" />
     <PackageReference Include="LykkeBiz.RabbitMqBroker" Version="11.9.2" />
     <PackageReference Include="Lykke.Service.EmailSender" Version="1.1.0" />
-    <PackageReference Include="Lykke.Snow.Common" Version="2.6.0" />
+    <PackageReference Include="Lykke.Snow.Common" Version="2.7.3" />
     <PackageReference Include="Lykke.Snow.Common.Startup" Version="3.0.1" />
     <PackageReference Include="Lykke.MarginTrading.AccountsManagement.Contracts" Version="7.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />

--- a/src/MarginTrading.Common/MarginTrading.Common.csproj
+++ b/src/MarginTrading.Common/MarginTrading.Common.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="LykkeBiz.SettingsReader" Version="6.0.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
-    <PackageReference Include="Lykke.Snow.Common" Version="2.6.0" />
+    <PackageReference Include="Lykke.Snow.Common" Version="2.7.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />


### PR DESCRIPTION
This PR upgrades all `Lykke.Snow.Common` packages to version 2.7.3, and aims at solving version-tag discrepancy for the versions older than 2.7.3.