### PR TITLE
Lt 4983 extend performance statistics

### DIFF
--- a/src/MarginTrading.Backend.Core/Settings/MarginTradingSettings.cs
+++ b/src/MarginTrading.Backend.Core/Settings/MarginTradingSettings.cs
@@ -128,6 +128,6 @@ namespace MarginTrading.Backend.Core.Settings
         [Optional] public FeatureManagement FeatureManagement { get; set; } = new FeatureManagement();
 
         // todo: probably should be moved turned in to a feature flag
-        [Optional] public bool PerformanceTrackerEnabled { get; set; } = false;
+        [Optional] public bool PerformanceLoggerEnabled { get; set; } = false;
     }
 }

--- a/src/MarginTrading.Backend.Services/Events/EventChannel.cs
+++ b/src/MarginTrading.Backend.Services/Events/EventChannel.cs
@@ -34,7 +34,13 @@ namespace MarginTrading.Backend.Services.Events
             {
                 try
                 {
-                    consumer.ConsumeEvent(sender, ea);
+                    var assetPairId = ea is BestPriceChangeEventArgs bestPriceChangeEventArgs
+                        ? bestPriceChangeEventArgs.BidAskPair.Instrument
+                        : "N/A";
+                    
+                    PerformanceTracker.Track(typeof(TEventArgs).Name, 
+                        () => consumer.ConsumeEvent(sender, ea), 
+                        assetPairId);
                 }
                 catch (Exception e)
                 {

--- a/src/MarginTrading.Backend.Services/Events/EventChannel.cs
+++ b/src/MarginTrading.Backend.Services/Events/EventChannel.cs
@@ -39,7 +39,7 @@ namespace MarginTrading.Backend.Services.Events
                     
                     var assetPairId = ea is BestPriceChangeEventArgs bestPriceChangeEventArgs
                         ? bestPriceChangeEventArgs.BidAskPair.Instrument
-                        : "N/A";
+                        : null;
                     
                     assetPairId = ea is FxBestPriceChangeEventArgs fxBestPriceChangeEventArgs
                         ? fxBestPriceChangeEventArgs.BidAskPair.Instrument

--- a/src/MarginTrading.Backend.Services/Events/EventChannel.cs
+++ b/src/MarginTrading.Backend.Services/Events/EventChannel.cs
@@ -34,11 +34,18 @@ namespace MarginTrading.Backend.Services.Events
             {
                 try
                 {
+                    var consumerName = consumer.GetType().Name;
+                    var eventName = typeof(TEventArgs).Name;
+                    
                     var assetPairId = ea is BestPriceChangeEventArgs bestPriceChangeEventArgs
                         ? bestPriceChangeEventArgs.BidAskPair.Instrument
                         : "N/A";
                     
-                    PerformanceTracker.Track(typeof(TEventArgs).Name, 
+                    assetPairId = ea is FxBestPriceChangeEventArgs fxBestPriceChangeEventArgs
+                        ? fxBestPriceChangeEventArgs.BidAskPair.Instrument
+                        : assetPairId;
+                    
+                    PerformanceTracker.Track($"{consumerName}:{eventName}", 
                         () => consumer.ConsumeEvent(sender, ea), 
                         assetPairId);
                 }

--- a/src/MarginTrading.Backend.Services/Events/EventChannel.cs
+++ b/src/MarginTrading.Backend.Services/Events/EventChannel.cs
@@ -45,9 +45,9 @@ namespace MarginTrading.Backend.Services.Events
                         ? fxBestPriceChangeEventArgs.BidAskPair.Instrument
                         : assetPairId;
                     
-                    PerformanceTracker.Track($"{consumerName}:{eventName}", 
-                        () => consumer.ConsumeEvent(sender, ea), 
-                        assetPairId);
+                    PerformanceTracker.Track(
+                        new PerformanceTracker.MethodIdentity(consumerName, eventName, assetPairId), 
+                        () => consumer.ConsumeEvent(sender, ea));
                 }
                 catch (Exception e)
                 {

--- a/src/MarginTrading.Backend.Services/Extensions/SqlExtensions.cs
+++ b/src/MarginTrading.Backend.Services/Extensions/SqlExtensions.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+namespace MarginTrading.Backend.Services.Extensions
+{
+    internal static class SqlExtensions
+    {
+        public static string ToSqlStatement(this PerformanceTracker.MethodStatistics stat, 
+            PerformanceTracker.MethodIdentity methodIdentity)
+        {
+            return $"INSERT INTO [dbo].[PerformanceStatistics] ([Owner], [Method], [Param], [CallsCounter], [TotalExecutionMs], [AverageExecutionMs], [MaxExecutionMs]) VALUES ('{methodIdentity.Owner}', '{methodIdentity.Name}', '{methodIdentity.Parameter}', {stat.CallsCounter}, {stat.TotalExecutionMs}, {stat.TotalExecutionMs / stat.CallsCounter}, {stat.MaxExecutionMs});";
+        }
+    }
+}

--- a/src/MarginTrading.Backend.Services/Extensions/SqlExtensions.cs
+++ b/src/MarginTrading.Backend.Services/Extensions/SqlExtensions.cs
@@ -1,14 +1,39 @@
 // Copyright (c) 2019 Lykke Corp.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
 namespace MarginTrading.Backend.Services.Extensions
 {
     internal static class SqlExtensions
     {
-        public static string ToSqlStatement(this PerformanceTracker.MethodStatistics stat, 
-            PerformanceTracker.MethodIdentity methodIdentity)
+        public static string ToBulkSqlStatement(
+            this IDictionary<PerformanceTracker.MethodIdentity, PerformanceTracker.MethodStatistics> stats)
         {
-            return $"INSERT INTO [dbo].[PerformanceStatistics] ([Owner], [Method], [Param], [CallsCounter], [TotalExecutionMs], [AverageExecutionMs], [MaxExecutionMs]) VALUES ('{methodIdentity.Owner}', '{methodIdentity.Name}', '{methodIdentity.Parameter}', {stat.CallsCounter}, {stat.TotalExecutionMs}, {stat.TotalExecutionMs / stat.CallsCounter}, {stat.MaxExecutionMs});";
+            var sql = new StringBuilder();
+            foreach (var chunk in stats.Chunk(1000))
+            {
+                sql.AppendLine(
+                    $"INSERT INTO [dbo].[PerformanceStatistics] ([Owner], [Method], [Param], [CallsCounter], [TotalExecutionMs], [AverageExecutionMs], [MaxExecutionMs]) VALUES");
+                
+                var values = new StringBuilder();
+                foreach (var (key, value) in chunk)
+                {
+                    if (values.Length > 0)
+                        values.Append(",");
+                    var line =
+                        $"('{key.Owner}', '{key.Name}', '{key.Parameter}', {value.CallsCounter}, {value.TotalExecutionMs}, {value.TotalExecutionMs / value.CallsCounter}, {value.MaxExecutionMs})";
+                    values.AppendLine(line);
+                }
+
+                values.Append(";");
+                values.AppendLine();
+                sql.Append(values);
+            }
+            
+            return sql.ToString();
         }
     }
 }

--- a/src/MarginTrading.Backend.Services/PerformanceInfoFormatter.cs
+++ b/src/MarginTrading.Backend.Services/PerformanceInfoFormatter.cs
@@ -10,13 +10,16 @@ namespace MarginTrading.Backend.Services
             var totalExecutionTimeFormatted = FormattingUtils.FormatMilliseconds(stat.TotalExecutionMs);
             var averageExecutionTimeFormatted =
                 FormattingUtils.FormatMilliseconds(stat.TotalExecutionMs / stat.CallsCounter);
+            var maxExecutionTimeFormatted = FormattingUtils.FormatMilliseconds(stat.MaxExecutionMs);
             
-            var methodInfo = $"Method: {methodKey}".PadRight(120);
-            var callsInfo = $"Calls: {stat.CallsCounter}".PadRight(20);
-            var totalExecutionTimeInfo = $"Total execution time: {totalExecutionTimeFormatted}".PadRight(40);
-            var averageExecutionTimeInfo = $"Average execution time: {averageExecutionTimeFormatted}".PadRight(40);
+            var methodInfo = $"Method: {methodKey}".PadRight(100);
+            var callsInfo = $"Calls: {stat.CallsCounter}".PadRight(15);
+            var totalExecutionTimeInfo = $"Total execution time: {totalExecutionTimeFormatted}".PadRight(30);
+            var averageExecutionTimeInfo = $"Average execution time: {averageExecutionTimeFormatted}".PadRight(30);
+            var maxExecutionTimeInfo = $"Max execution time: {maxExecutionTimeFormatted}".PadRight(25);
 
-            return $"{methodInfo} | {callsInfo} | {totalExecutionTimeInfo} | {averageExecutionTimeInfo}";
+            return
+                $"{methodInfo} | {callsInfo} | {totalExecutionTimeInfo} | {averageExecutionTimeInfo} | {maxExecutionTimeInfo}";
         }
 
         public static string FormatPositionStatistics(string assetPairId, int counter)

--- a/src/MarginTrading.Backend.Services/PerformanceInfoFormatter.cs
+++ b/src/MarginTrading.Backend.Services/PerformanceInfoFormatter.cs
@@ -11,7 +11,7 @@ namespace MarginTrading.Backend.Services
             var averageExecutionTimeFormatted =
                 FormattingUtils.FormatMilliseconds(stat.TotalExecutionMs / stat.CallsCounter);
             var maxExecutionTimeFormatted = FormattingUtils.FormatMilliseconds(stat.MaxExecutionMs);
-            
+
             var methodInfo = $"Method: {methodKey}".PadRight(100);
             var callsInfo = $"Calls: {stat.CallsCounter}".PadRight(15);
             var totalExecutionTimeInfo = $"Total execution time: {totalExecutionTimeFormatted}".PadRight(30);
@@ -26,7 +26,7 @@ namespace MarginTrading.Backend.Services
         {
             var assetInfo = $"Asset: {assetPairId}".PadRight(100);
             var countInfo = $"Count: {counter}".PadRight(20);
-                
+
             return $"{assetInfo} | {countInfo}";
         }
     }

--- a/src/MarginTrading.Backend.Services/PerformanceLogger.cs
+++ b/src/MarginTrading.Backend.Services/PerformanceLogger.cs
@@ -43,7 +43,7 @@ namespace MarginTrading.Backend.Services
             sb.AppendLine("=======-Performance statistics-==========");
             foreach (var stat in PerformanceTracker.Statistics)
             {
-                var line = PerformanceInfoFormatter.FormatMethodStatistics(stat.Key, stat.Value);
+                var line = PerformanceInfoFormatter.FormatMethodStatistics(stat.Key.ToString(), stat.Value);
                 sb.AppendLine(line);
             }
             sb.AppendLine("====-Performance statistics (end)-=======");

--- a/src/MarginTrading.Backend.Services/PerformanceLogger.cs
+++ b/src/MarginTrading.Backend.Services/PerformanceLogger.cs
@@ -36,7 +36,7 @@ namespace MarginTrading.Backend.Services
             }
         }
 
-        private static string PrintPerformanceStatistics()
+        public static string PrintPerformanceStatistics()
         {
             var sb = new StringBuilder();
             sb.AppendLine();

--- a/src/MarginTrading.Backend.Services/PerformanceStatisticsSqlFormatter.cs
+++ b/src/MarginTrading.Backend.Services/PerformanceStatisticsSqlFormatter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2019 Lykke Corp.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
 using System.Text;
 using MarginTrading.Backend.Services.Extensions;
 
@@ -14,12 +13,8 @@ namespace MarginTrading.Backend.Services
             var sql = new StringBuilder();
             sql.AppendLine(Ddl);
 
-            return PerformanceTracker.Statistics.Aggregate(sql, (sb, s) =>
-            {
-                var line = s.Value.ToSqlStatement(s.Key);
-                sb.AppendLine(line);
-                return sb;
-            }).ToString();
+            var bulkInsertions = PerformanceTracker.Statistics.ToBulkSqlStatement();
+            return sql.AppendLine(bulkInsertions).ToString();
         }
 
         private static string Ddl =>

--- a/src/MarginTrading.Backend.Services/PerformanceStatisticsSqlFormatter.cs
+++ b/src/MarginTrading.Backend.Services/PerformanceStatisticsSqlFormatter.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2019 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Text;
+using MarginTrading.Backend.Services.Extensions;
+
+namespace MarginTrading.Backend.Services
+{
+    public static class PerformanceStatisticsSqlFormatter
+    {
+        public static string GenerateInsertions()
+        {
+            var sql = new StringBuilder();
+            sql.AppendLine(Ddl);
+
+            return PerformanceTracker.Statistics.Aggregate(sql, (sb, s) =>
+            {
+                var line = s.Value.ToSqlStatement(s.Key);
+                sb.AppendLine(line);
+                return sb;
+            }).ToString();
+        }
+
+        private static string Ddl =>
+            $@"
+use nova
+
+if object_id('dbo.PerformanceStatistics', 'U') is not null
+    truncate table [dbo].[PerformanceStatistics]
+else
+    CREATE TABLE dbo.PerformanceStatistics
+    (
+        Owner NVARCHAR(100) NOT NULL,
+        Method NVARCHAR(100) NOT NULL,
+        Param NVARCHAR(100) NOT NULL,
+        CallsCounter INT NOT NULL,
+        TotalExecutionMs BIGINT NOT NULL,
+        AverageExecutionMs BIGINT NOT NULL,
+        MaxExecutionMs BIGINT NOT NULL,
+        PRIMARY KEY (Owner, Method, Param)
+    )
+
+";
+    }
+}

--- a/src/MarginTrading.Backend.Services/PerformanceTracker.cs
+++ b/src/MarginTrading.Backend.Services/PerformanceTracker.cs
@@ -13,14 +13,17 @@ namespace MarginTrading.Backend.Services
     {
         public struct MethodStatistics
         {
-            public MethodStatistics(int callsCounter, long totalExecutionMs)
+            public MethodStatistics(int callsCounter, long totalExecutionMs, long maxExecutionMs)
             {
                 CallsCounter = callsCounter;
                 TotalExecutionMs = totalExecutionMs;
+                MaxExecutionMs = maxExecutionMs;
             }
 
             public int CallsCounter { get; }
             public long TotalExecutionMs { get; }
+            
+            public long MaxExecutionMs { get; }
         }
         
         public static readonly ConcurrentDictionary<string, MethodStatistics> Statistics =
@@ -68,8 +71,11 @@ namespace MarginTrading.Backend.Services
             
             var elapsedMs = watch.ElapsedMilliseconds;
 
-            Statistics.AddOrUpdate(key, new MethodStatistics(1, elapsedMs),
-                (_, stats) => new MethodStatistics(stats.CallsCounter + 1, stats.TotalExecutionMs + elapsedMs));
+            Statistics.AddOrUpdate(key, new MethodStatistics(1, elapsedMs, elapsedMs),
+                (_, stats) => new MethodStatistics(
+                    stats.CallsCounter + 1,
+                    stats.TotalExecutionMs + elapsedMs,
+                    elapsedMs > stats.MaxExecutionMs ? elapsedMs : stats.MaxExecutionMs));
         }
 
         private static string GetKey(string methodName, [CanBeNull] string assetPair)

--- a/src/MarginTrading.Backend.Services/Quotes/PricesUpdateRabbitMqNotifier.cs
+++ b/src/MarginTrading.Backend.Services/Quotes/PricesUpdateRabbitMqNotifier.cs
@@ -18,9 +18,7 @@ namespace MarginTrading.Backend.Services.Quotes
         int IEventConsumer.ConsumerRank => 110;
         void IEventConsumer<BestPriceChangeEventArgs>.ConsumeEvent(object sender, BestPriceChangeEventArgs ea)
         {
-            PerformanceTracker.TrackAsync("PublishBestPrice",
-                async () => await _rabbitMqNotifyService.OrderBookPrice(ea.BidAskPair, ea.IsEod), 
-                ea.BidAskPair.Instrument).GetAwaiter().GetResult();
+            _rabbitMqNotifyService.OrderBookPrice(ea.BidAskPair, ea.IsEod);
         }
     }
 }

--- a/src/MarginTrading.Backend/Controllers/PerformanceController.cs
+++ b/src/MarginTrading.Backend/Controllers/PerformanceController.cs
@@ -8,6 +8,12 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace MarginTrading.Backend.Controllers
 {
+    public enum StatisticsFormat
+    {
+        Text,
+        Sql
+    }
+    
     [Route("api/performance")]
     [ApiController]
     public class PerformanceController : ControllerBase
@@ -17,10 +23,21 @@ namespace MarginTrading.Backend.Controllers
         /// </summary>
         /// <returns></returns>
         [HttpGet("report")]
-        public Task<IActionResult> GetStatisticsReport()
+        public Task<IActionResult> GetStatisticsReport([FromQuery] StatisticsFormat format = StatisticsFormat.Text)
         {
-            var txtReport = PerformanceLogger.PrintPerformanceStatistics();
-            var fileContent = File(Encoding.UTF8.GetBytes(txtReport), "text/plain", "performance.txt");
+            FileContentResult fileContent = null;
+            if (format == StatisticsFormat.Text)
+            {
+                var txtReport = PerformanceLogger.PrintPerformanceStatistics();
+                fileContent = File(Encoding.UTF8.GetBytes(txtReport), "text/plain", "performance.txt");    
+            }
+
+            if (format == StatisticsFormat.Sql)
+            {
+                var sql = PerformanceStatisticsSqlFormatter.GenerateInsertions();
+                fileContent = File(Encoding.UTF8.GetBytes(sql), "text/plain", "performance.sql");
+            }
+            
             return Task.FromResult((IActionResult)fileContent);
         }
         

--- a/src/MarginTrading.Backend/Controllers/PerformanceController.cs
+++ b/src/MarginTrading.Backend/Controllers/PerformanceController.cs
@@ -10,7 +10,7 @@ namespace MarginTrading.Backend.Controllers
 {
     [Route("api/performance")]
     [ApiController]
-    public class PerformanceStatController : ControllerBase
+    public class PerformanceController : ControllerBase
     {
         /// <summary>
         /// Create statistics report for performance and return it as text file
@@ -22,6 +22,17 @@ namespace MarginTrading.Backend.Controllers
             var txtReport = PerformanceLogger.PrintPerformanceStatistics();
             var fileContent = File(Encoding.UTF8.GetBytes(txtReport), "text/plain", "performance.txt");
             return Task.FromResult((IActionResult)fileContent);
+        }
+        
+        /// <summary>
+        /// Resets statistics report for performance
+        /// </summary>
+        /// <returns></returns>
+        [HttpPost("report")]
+        public Task<IActionResult> ResetStatisticsReport()
+        {
+            PerformanceTracker.Statistics.Clear();
+            return Task.FromResult((IActionResult)Ok());
         }
     }
 }

--- a/src/MarginTrading.Backend/Controllers/PerformanceStatController.cs
+++ b/src/MarginTrading.Backend/Controllers/PerformanceStatController.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using System.Threading.Tasks;
+using MarginTrading.Backend.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MarginTrading.Backend.Controllers
+{
+    [Route("api/performance")]
+    [ApiController]
+    public class PerformanceStatController : ControllerBase
+    {
+        /// <summary>
+        /// Create statistics report for performance and return it as text file
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("report")]
+        public Task<IActionResult> GetStatisticsReport()
+        {
+            var txtReport = PerformanceLogger.PrintPerformanceStatistics();
+            var fileContent = File(Encoding.UTF8.GetBytes(txtReport), "text/plain", "performance.txt");
+            return Task.FromResult((IActionResult)fileContent);
+        }
+    }
+}

--- a/src/MarginTrading.Backend/Startup.cs
+++ b/src/MarginTrading.Backend/Startup.cs
@@ -319,8 +319,8 @@ namespace MarginTrading.Backend
 
             services.AddSingleton<ILoggerFactory>(x => new WebHostLoggerFactory(LogLocator.CommonLog));
 
-            PerformanceTracker.Enabled = settings.CurrentValue.PerformanceTrackerEnabled;
-            if (PerformanceTracker.Enabled)
+            PerformanceTracker.Enabled = true;
+            if (settings.CurrentValue.PerformanceLoggerEnabled)
             {
                 services.AddHostedService<PerformanceLogger>();
             }


### PR DESCRIPTION
Following features have been added:

- new MaxExecution time statistics
- disabling performance logger by default with an option to enable it
- performance statistics can now be fetched via endpoint in two flavours: text format and SQL format
- SQL format in essence is a set of statements to create table and import statistics data, to operate with it later in a more flexible way
- extend performance statistics scope and cover all consumers