### PR TITLE
fix(LT-5298): increase the criticality of the message when snapshot w…

### DIFF
--- a/src/MarginTrading.Backend.Services/Extensions/TradingEngineSnapshotExtensions.cs
+++ b/src/MarginTrading.Backend.Services/Extensions/TradingEngineSnapshotExtensions.cs
@@ -88,6 +88,9 @@ namespace MarginTrading.Backend.Services.Extensions
         public static bool IsPlatformClosureEvent(this MarketStateChangedEvent evt) =>
             evt.Id == LykkeConstants.PlatformMarketIdentifier && !evt.IsEnabled;
         
+        public static bool IsNotPlatformClosureEvent(this MarketStateChangedEvent evt) =>
+            !evt.IsPlatformClosureEvent();
+        
         private static List<T> GetOrders<T>(this TradingEngineSnapshot snapshot)
         {
             return string.IsNullOrWhiteSpace(snapshot.OrdersJson)


### PR DESCRIPTION
…as not created

The only reason to avoid the error is when the platform closure event is related to the trading day in the past (assume stale event)